### PR TITLE
Add authentication flow and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,27 @@ npm run server
 
 This starts the API on `http://localhost:4000` with both REST endpoints and GraphQL available at `/graphql`.
 
+## Frontend
+
+1. Start the Vite development server in a separate terminal:
+
+```bash
+npm run dev
+```
+
+The application will be available at `http://localhost:5173`.
+
+### Authentication and Dashboard
+
+1. Register a user (only once) by sending a POST request to the backend:
+
+```bash
+curl -X POST http://localhost:4000/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email":"test@example.com","password":"test"}'
+```
+
+2. Visit `http://localhost:5173/login` and log in with the credentials you created. After successful login you will be redirected to the dashboard.
+
+3. The dashboard at `http://localhost:5173/dashboard` displays articles fetched from `/articles` and can only be accessed while a token is stored in `localStorage`.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import HomePage from './pages/HomePage';
 import Index from './pages/Index';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
 import NotFound from './pages/NotFound';
 import { ToastProvider } from './hooks/use-toast';
 
@@ -22,6 +24,8 @@ const App: React.FC = () => {
             <Routes>
               <Route path="/" element={<HomePage />} />
               <Route path="/index" element={<Index />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/dashboard" element={<Dashboard />} />
               {/* add more routes here as you build additional pages */}
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '../hooks/use-toast';
+import type { Article } from '../lib/types';
+
+/**
+ * Simple dashboard that requires a JWT token to view. It lists articles
+ * from the backend and provides a logout button.
+ */
+const Dashboard: React.FC = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [articles, setArticles] = React.useState<Article[]>([]);
+
+  React.useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+    fetch('http://localhost:4000/articles', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then((data) => setArticles(data))
+      .catch((err) => {
+        console.error(err);
+        toast({ title: 'Greška pri dohvaćanju članaka' });
+      });
+  }, [navigate, toast]);
+
+  function handleLogout() {
+    localStorage.removeItem('token');
+    navigate('/login');
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-semibold">Nadzorna ploča</h1>
+        <button
+          onClick={handleLogout}
+          className="px-3 py-1 bg-gray-200 rounded hover:bg-gray-300"
+        >
+          Odjava
+        </button>
+      </div>
+      <section>
+        <h2 className="text-xl font-semibold mb-2">Članci</h2>
+        {articles.length === 0 ? (
+          <p>Nema dostupnih članaka.</p>
+        ) : (
+          <ul className="list-disc list-inside space-y-1">
+            {articles.map((article) => (
+              <li key={article.id}>{article.title}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useToast } from '../hooks/use-toast';
+
+/**
+ * Login form that posts credentials to `/auth/login`. On success the
+ * returned JWT token is stored in `localStorage` and the user is
+ * redirected to the dashboard.
+ */
+const Login: React.FC = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [email, setEmail] = React.useState('');
+  const [password, setPassword] = React.useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      const res = await fetch('http://localhost:4000/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        toast({ title: 'Neuspjela prijava' });
+        return;
+      }
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      toast({ title: 'Prijavljeni ste' });
+      navigate('/dashboard');
+    } catch (err) {
+      console.error(err);
+      toast({ title: 'Greška pri spajanju na server' });
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4 bg-white p-6 rounded shadow w-80"
+      >
+        <h1 className="text-xl font-semibold text-center">Prijava</h1>
+        <div className="flex flex-col space-y-1">
+          <label htmlFor="email" className="text-sm font-medium">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <div className="flex flex-col space-y-1">
+          <label htmlFor="password" className="text-sm font-medium">
+            Lozinka
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="border px-3 py-2 rounded"
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="w-full py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          Prijavi se
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- add login form and dashboard page
- store token in localStorage and restrict dashboard access
- register new routes for login and dashboard
- document how to run the dev server, register and log in

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688944bd41548327b5b557ea268e48d0