### PR TITLE
Update database provider default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://lovable.dev/projects/36820b65-f536-4f4f-baef-e50c17c50536
 The contents here mirror the folder structure and source files visible in Lovable's code view.  You can continue building the project in Lovable or use this as a reference in your own IDE.
 ## Backend
 
-A simple Express + Prisma backend lives in the `server/` folder. The project uses SQLite by default but can switch to another database by editing `DATABASE_PROVIDER` and `DATABASE_URL` in `.env`.
+A simple Express + Prisma backend lives in the `server/` folder. The Prisma schema is configured for SQLite by default. To use another database, update the `provider` field in `server/prisma/schema.prisma` and the `DATABASE_URL` value in `.env`.
 
 ### Setup
 

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,5 +1,5 @@
 datasource db {
-  provider = env("DATABASE_PROVIDER")
+  provider = "sqlite"
   url      = env("DATABASE_URL")
 }
 


### PR DESCRIPTION
## Summary
- set Prisma database provider to `"sqlite"`
- clarify backend setup in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68894ebbe00c8327baf79cc4f8554381