### PR TITLE
Fix admin dashboard docs and add login link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This starts the API on `http://localhost:4000` with both REST endpoints and Grap
 npm run dev
 ```
 
-The application will be available at `http://localhost:5173`.
+The application will be available at `http://localhost:8080`.
 
 ### Authentication and Dashboard
 
@@ -49,7 +49,7 @@ curl -X POST http://localhost:4000/auth/register \
   -d '{"email":"test@example.com","password":"test"}'
 ```
 
-2. Visit `http://localhost:5173/login` and log in with the credentials you created. After successful login you will be redirected to the dashboard.
+2. Visit `http://localhost:8080/login` and log in with the credentials you created. After successful login you will be redirected to the dashboard.
 
-3. The dashboard at `http://localhost:5173/dashboard` displays articles fetched from `/articles` and can only be accessed while a token is stored in `localStorage`.
+3. The dashboard at `http://localhost:8080/dashboard` displays articles fetched from `/articles` and can only be accessed while a token is stored in `localStorage`.
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,8 @@ const Header: React.FC = () => {
     { name: "Kalendar", href: "/kalendar" },
   ];
 
+  const token = localStorage.getItem('token');
+
   const isActive = (href: string) => {
     if (href === "/") {
       return location.pathname === "/";
@@ -42,6 +44,12 @@ const Header: React.FC = () => {
               {item.name}
             </Link>
           ))}
+          <Link
+            to={token ? "/dashboard" : "/login"}
+            className="text-sm font-medium text-gray-600 hover:text-blue-700"
+          >
+            {token ? "Dashboard" : "Prijava"}
+          </Link>
         </nav>
         {/* Simple mobile menu toggle - optional */}
         <div className="md:hidden">


### PR DESCRIPTION
## Summary
- correct ports in README for local dashboard access
- show login/dashboard link in header depending on auth state

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68896617527c8327a51e0ef94b5aa109