### PR TITLE
Make API base configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 DATABASE_URL="postgresql://user:password@localhost:5432/vjera_local"
 DATABASE_PROVIDER="postgresql"
 JWT_SECRET="change-me"
+VITE_API_BASE="http://localhost:4000"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project combines a small Express API with a React frontend. The backend liv
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and update the values for your database connection and JWT secret.
+1. Copy `.env.example` to `.env` and update the values for your database connection, JWT secret and `VITE_API_BASE` if needed.
 2. Install dependencies and run the database migrations:
    ```bash
    npm install
@@ -18,7 +18,7 @@ This project combines a small Express API with a React frontend. The backend liv
    ```bash
    npm run server
    ```
-   The API will be available at `http://localhost:4000` with REST and GraphQL endpoints.
+   The API will be available at `http://localhost:4000` by default with REST and GraphQL endpoints. Set `VITE_API_BASE` accordingly for the frontend.
 4. In a separate terminal run the frontend:
    ```bash
    npm run dev
@@ -34,7 +34,7 @@ The API automatically ensures an administrator account exists:
 
 Use these credentials on the `/login` page to access the dashboard. To create additional users run:
 ```bash
-curl -X POST http://localhost:4000/auth/register \
+curl -X POST $VITE_API_BASE/auth/register \
   -H "Content-Type: application/json" \
   -d '{"email":"you@example.com","password":"secret"}'
 ```

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -18,7 +18,7 @@ const Dashboard: React.FC = () => {
       navigate('/login');
       return;
     }
-    fetch('http://localhost:4000/articles', {
+    fetch(`${import.meta.env.VITE_API_BASE}/articles`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((res) => res.json())

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -16,7 +16,7 @@ const Login: React.FC = () => {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     try {
-      const res = await fetch('http://localhost:4000/auth/login', {
+      const res = await fetch(`${import.meta.env.VITE_API_BASE}/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),


### PR DESCRIPTION
## Summary
- use `VITE_API_BASE` env variable for client requests
- document the new variable in `.env.example` and README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6889713388588327ac24cc1f57fd4934