### PR TITLE
Fix dashboard auth check and restore API helpers

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,16 @@
+import type { Article, Event, Category, Author } from './types';
+
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:4000';
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${path}`);
+  }
+  return res.json();
+}
+
+export const fetchArticles = () => get<Article[]>('/articles');
+export const fetchEvents = () => get<Event[]>('/events');
+export const fetchCategories = () => get<Category[]>('/categories');
+export const fetchAuthors = () => get<Author[]>('/authors');

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ const Dashboard: React.FC = () => {
     if (!localStorage.getItem('token')) {
       navigate('/login');
     }
-
+  }, [navigate]);
 
   function handleLogout() {
     localStorage.removeItem('token');


### PR DESCRIPTION
## Summary
- restore missing API helper functions for fetching articles, events, categories, and authors
- fix effect cleanup in Dashboard page so it redirects correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6889f4c9b4748327a785295a00d166d3