### PR TITLE
Update event types and adjust frontend

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@
  */
 
 export interface Article {
-  id: string;
+  id: number;
   slug: string;
   title: string;
   summary: string;
@@ -13,8 +13,8 @@ export interface Article {
   status: 'draft' | 'review' | 'scheduled' | 'published';
   type: 'vijest' | 'analiza' | 'kolumna' | 'intervju' | 'duhovnost';
   denomination: 'katoličko' | 'pravoslavno' | 'protestantsko' | 'ekumensko';
-  authorId: string;
-  categoryId: string;
+  authorId: number;
+  categoryId: number;
   tags: string[];
   sourceName?: string;
   sourceUrl?: string;
@@ -32,7 +32,7 @@ export interface Article {
 }
 
 export interface Author {
-  id: string;
+  id: number;
   name: string;
   slug: string;
   bio: string;
@@ -45,23 +45,19 @@ export interface Author {
 }
 
 export interface Category {
-  id: string;
+  id: number;
   name: string;
   slug: string;
   color: string;
 }
 
-export interface EventLocation {
-  city: string;
-  country: string;
-}
-
 export interface Event {
-  id: string;
+  id: number;
   title: string;
   slug: string;
   description: string;
-  location: EventLocation;
+  city: string;
+  country: string;
   denomination: Category['slug'];
   startsAt: string;
   endsAt: string;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -146,7 +146,7 @@ const HomePage: React.FC = () => {
                 <div>
                   <strong>{event.title}</strong>
                   <p className="text-sm text-gray-600">
-                    {event.location.city}, {event.location.country}
+                    {event.city}, {event.country}
                   </p>
                 </div>
                 <span className="text-sm text-gray-500">{new Date(event.startsAt).toLocaleDateString('hr-HR')}</span>

--- a/src/pages/dashboard/Events.tsx
+++ b/src/pages/dashboard/Events.tsx
@@ -37,12 +37,12 @@ const Events: React.FC = () => {
     const url = editing
       ? `http://localhost:4000/events/${editing}`
       : 'http://localhost:4000/events';
-    const payload = {
-      title: form.title,
-      slug: form.slug,
-      description: (form as any).description || '',
-      city: (form as any).location?.city || '',
-      country: (form as any).location?.country || '',
+      const payload = {
+        title: form.title,
+        slug: form.slug,
+        description: (form as any).description || '',
+        city: (form as any).city || '',
+        country: (form as any).country || '',
       denomination: (form as any).denomination || 'katolicko',
       startsAt: (form as any).startsAt || new Date().toISOString(),
       endsAt: (form as any).endsAt || new Date().toISOString(),


### PR DESCRIPTION
## Summary
- update core data types to use numeric IDs
- replace `Event.location` with `city` and `country`
- update homepage and dashboard forms to use new `Event` fields

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6889f8a09ae88327906c544a45b3af56