### PR TITLE
Ignore env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,0 @@
-# .env
-
-DATABASE_URL="postgresql://postgres:123456@localhost:5432/vjera_local"
-DATABASE_PROVIDER="postgresql"
-JWT_SECRET="123456"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist-ssr
 .sln
 *.sw?
 server/.env
+.env

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project combines a small Express API with a React frontend. The backend liv
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and update the values for your database connection, JWT secret and `VITE_API_BASE` if needed.
+1. Copy `.env.example` to `.env` and update the values for your database connection, JWT secret and `VITE_API_BASE` if needed. This file is ignored by Git so your credentials stay local.
 2. Install dependencies and run the database migrations:
    ```bash
    npm install


### PR DESCRIPTION
## Summary
- ignore `.env`
- note that `.env` is copied from `.env.example` and ignored by git

## Testing
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6889f89df7c083278c98aee2b2dafb88